### PR TITLE
fix: Reuse existing error variable instead of instantitaing new ones.…

### DIFF
--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -403,19 +403,19 @@ func (s ThingWeaviateModel) Upsert(ctx context.Context, client *weaviate.Client,
 	}
 }
 
-func (s ThingWeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (*data.ObjectWrapper, error) {
-	_, err := s.AssociatedThing.Upsert(ctx, client, consistencyLevel)
+func (s ThingWeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
+	_, err = s.AssociatedThing.Upsert(ctx, client, consistencyLevel)
 	if err != nil {
 		return nil, err
 	}
 	if s.OptionalAssociatedThing != nil {
-		_, err := s.OptionalAssociatedThing.Upsert(ctx, client, consistencyLevel)
+		_, err = s.OptionalAssociatedThing.Upsert(ctx, client, consistencyLevel)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for _, crossReference := range s.RepeatedMessages {
-		_, err := crossReference.Upsert(ctx, client, consistencyLevel)
+		_, err = crossReference.Upsert(ctx, client, consistencyLevel)
 		if err != nil {
 			return nil, err
 		}
@@ -428,21 +428,21 @@ func (s ThingWeaviateModel) Create(ctx context.Context, client *weaviate.Client,
 		Do(ctx)
 }
 
-func (s ThingWeaviateModel) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) error {
-	_, err := s.AssociatedThing.Upsert(ctx, client, consistencyLevel)
+func (s ThingWeaviateModel) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) (err error) {
+	_, err = s.AssociatedThing.Upsert(ctx, client, consistencyLevel)
 	if err != nil {
-		return err
+		return
 	}
 	if s.OptionalAssociatedThing != nil {
-		_, err := s.OptionalAssociatedThing.Upsert(ctx, client, consistencyLevel)
+		_, err = s.OptionalAssociatedThing.Upsert(ctx, client, consistencyLevel)
 		if err != nil {
-			return err
+			return
 		}
 	}
 	for _, crossReference := range s.RepeatedMessages {
-		_, err := crossReference.Upsert(ctx, client, consistencyLevel)
+		_, err = crossReference.Upsert(ctx, client, consistencyLevel)
 		if err != nil {
-			return err
+			return
 		}
 	}
 	return client.Data().Updater().
@@ -582,7 +582,7 @@ func (s Thing2WeaviateModel) Upsert(ctx context.Context, client *weaviate.Client
 	}
 }
 
-func (s Thing2WeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (*data.ObjectWrapper, error) {
+func (s Thing2WeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
 	return client.Data().Creator().
 		WithClassName(s.WeaviateClassName()).
 		WithProperties(s.Data()).
@@ -591,7 +591,7 @@ func (s Thing2WeaviateModel) Create(ctx context.Context, client *weaviate.Client
 		Do(ctx)
 }
 
-func (s Thing2WeaviateModel) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) error {
+func (s Thing2WeaviateModel) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) (err error) {
 	return client.Data().Updater().
 		WithClassName(s.WeaviateClassName()).
 		WithID(lo.FromPtr(s.Id)).

--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -406,18 +406,18 @@ func (s ThingWeaviateModel) Upsert(ctx context.Context, client *weaviate.Client,
 func (s ThingWeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
 	_, err = s.AssociatedThing.Upsert(ctx, client, consistencyLevel)
 	if err != nil {
-		return nil, err
+		return
 	}
 	if s.OptionalAssociatedThing != nil {
 		_, err = s.OptionalAssociatedThing.Upsert(ctx, client, consistencyLevel)
 		if err != nil {
-			return nil, err
+			return
 		}
 	}
 	for _, crossReference := range s.RepeatedMessages {
 		_, err = crossReference.Upsert(ctx, client, consistencyLevel)
 		if err != nil {
-			return nil, err
+			return
 		}
 	}
 	return client.Data().Creator().

--- a/plugin/weaviate_template.go
+++ b/plugin/weaviate_template.go
@@ -260,12 +260,12 @@ func (s {{ structName . }}) Upsert(ctx context.Context, client *weaviate.Client,
 	}
 }
 
-func (s {{ structName . }}) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (*data.ObjectWrapper, error) {
+func (s {{ structName . }}) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
 	{{- range .Fields }}
 	  {{- if fieldIsCrossReference . -}}
         {{- if fieldIsRepeated . }}
           for _, crossReference := range s.{{ structFieldName . }} {
-			_, err := crossReference.Upsert(ctx, client, consistencyLevel)
+			_, err = crossReference.Upsert(ctx, client, consistencyLevel)
             if err != nil {
               return nil, err
             }
@@ -273,13 +273,13 @@ func (s {{ structName . }}) Create(ctx context.Context, client *weaviate.Client,
         {{- else }}
         {{- if fieldIsOptional . }}
         if s.{{ structFieldName . }} != nil {
-		  _, err := s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
+		  _, err = s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
 		  if err != nil {
 		    return nil, err
 		  }
         }
         {{- else }}
-          _, err := s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
+          _, err = s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
 		  if err != nil {
 		    return nil, err
 		  }
@@ -299,28 +299,28 @@ func (s {{ structName . }}) Create(ctx context.Context, client *weaviate.Client,
 		Do(ctx)
 }
 
-func (s {{ structName . }}) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) error {
+func (s {{ structName . }}) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) (err error) {
 	{{- range .Fields }}
 	  {{- if fieldIsCrossReference . -}}
         {{- if fieldIsRepeated . }}
           for _, crossReference := range s.{{ structFieldName . }} {
-			_, err := crossReference.Upsert(ctx, client, consistencyLevel)
+			_, err = crossReference.Upsert(ctx, client, consistencyLevel)
             if err != nil {
-              return err
+              return
             }
 	      }
         {{- else }}
         {{- if fieldIsOptional . }}
         if s.{{ structFieldName . }} != nil {
-		  _, err := s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
+		  _, err = s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
 		  if err != nil {
-		    return err
+		    return
 		  }
         }
         {{- else }}
-          _, err := s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
+          _, err = s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
 		  if err != nil {
-		    return err
+		    return
 		  }
         {{- end }}
 		{{- end }}

--- a/plugin/weaviate_template.go
+++ b/plugin/weaviate_template.go
@@ -267,7 +267,7 @@ func (s {{ structName . }}) Create(ctx context.Context, client *weaviate.Client,
           for _, crossReference := range s.{{ structFieldName . }} {
 			_, err = crossReference.Upsert(ctx, client, consistencyLevel)
             if err != nil {
-              return nil, err
+              return
             }
 	      }
         {{- else }}
@@ -275,13 +275,13 @@ func (s {{ structName . }}) Create(ctx context.Context, client *weaviate.Client,
         if s.{{ structFieldName . }} != nil {
 		  _, err = s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
 		  if err != nil {
-		    return nil, err
+		    return
 		  }
         }
         {{- else }}
           _, err = s.{{ structFieldName . }}.Upsert(ctx, client, consistencyLevel)
 		  if err != nil {
-		    return nil, err
+		    return
 		  }
         {{- end }}
 		{{- end }}


### PR DESCRIPTION
… Instantiating new error variables is problematic when there are many relationships.