### PR TITLE
fix: Simplify summary generation, fix race condition bug

### DIFF
--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -2,6 +2,7 @@ package example_example
 
 import (
 	json "encoding/json"
+	logging "github.com/catalystsquad/app-utils-go/logging"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	regexp "regexp"
 	strings "strings"
@@ -928,5 +929,6 @@ func getStringValue(x interface{}) (value string, err error) {
 	}
 	summaryString := summaryRegex.ReplaceAllString(string(jsonBytes), " ")
 	value = strings.ToLower(summaryString)
+	logging.Log.WithField("summary", value).Info("created summary")
 	return
 }

--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -2,10 +2,8 @@ package example_example
 
 import (
 	json "encoding/json"
-	logging "github.com/catalystsquad/app-utils-go/logging"
-	logrus "github.com/sirupsen/logrus"
-	gjson "github.com/tidwall/gjson"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	"regexp"
 	strings "strings"
 	time "time"
 )
@@ -19,6 +17,8 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"strconv"
 )
+
+var summaryRegex = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
 
 type ThingWeaviateModel struct {
 
@@ -926,16 +926,7 @@ func getStringValue(x interface{}) (value string, err error) {
 	if jsonBytes, err = json.Marshal(x); err != nil {
 		return
 	}
-	values := gjson.GetBytes(jsonBytes, "@values")
-	logging.Log.WithFields(logrus.Fields{"json": string(jsonBytes), "values": values.String()}).Info("building summary string")
-	builder := new(strings.Builder)
-	for _, result := range values.Array() {
-		resultString := result.String()
-		if resultString != "" {
-			builder.WriteString(resultString)
-			builder.WriteString(" ")
-		}
-	}
-	value = strings.ToLower(builder.String())
+	summaryString := summaryRegex.ReplaceAllString(string(jsonBytes), "")
+	value = strings.ToLower(summaryString)
 	return
 }

--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -2,6 +2,8 @@ package example_example
 
 import (
 	json "encoding/json"
+	logging "github.com/catalystsquad/app-utils-go/logging"
+	logrus "github.com/sirupsen/logrus"
 	gjson "github.com/tidwall/gjson"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	strings "strings"
@@ -924,8 +926,10 @@ func getStringValue(x interface{}) (value string, err error) {
 	if jsonBytes, err = json.Marshal(x); err != nil {
 		return
 	}
+	values := gjson.GetBytes(jsonBytes, "@values")
+	logging.Log.WithFields(logrus.Fields{"json": string(jsonBytes), "values": values.String()}).Info("building summary string")
 	builder := new(strings.Builder)
-	for _, result := range gjson.GetBytes(jsonBytes, "@values").Array() {
+	for _, result := range values.Array() {
 		resultString := result.String()
 		if resultString != "" {
 			builder.WriteString(resultString)

--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -3,7 +3,7 @@ package example_example
 import (
 	json "encoding/json"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	"regexp"
+	regexp "regexp"
 	strings "strings"
 	time "time"
 )
@@ -18,7 +18,7 @@ import (
 	"strconv"
 )
 
-var summaryRegex = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
+var summaryRegex = regexp.MustCompile("[^a-zA-Z0-9 ]+")
 
 type ThingWeaviateModel struct {
 

--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 )
 
-var summaryRegex = regexp.MustCompile("[^a-zA-Z0-9 ]+")
+var summaryRegex = regexp.MustCompile("[^-'\\\\.a-zA-Z0-9 ]+")
 
 type ThingWeaviateModel struct {
 
@@ -926,7 +926,7 @@ func getStringValue(x interface{}) (value string, err error) {
 	if jsonBytes, err = json.Marshal(x); err != nil {
 		return
 	}
-	summaryString := summaryRegex.ReplaceAllString(string(jsonBytes), "")
+	summaryString := summaryRegex.ReplaceAllString(string(jsonBytes), " ")
 	value = strings.ToLower(summaryString)
 	return
 }

--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -78,7 +78,7 @@ type ThingWeaviateModel struct {
 	OptionalTimestamp *time.Time `json:"optionalTimestamp" fake:"skip"`
 }
 
-func (s ThingWeaviateModel) ToProto() (theProto *Thing, err error) {
+func (s *ThingWeaviateModel) ToProto() (theProto *Thing, err error) {
 	theProto = &Thing{}
 
 	if s.Id != nil {
@@ -223,11 +223,11 @@ func (s *Thing) ToWeaviateModel() (model *ThingWeaviateModel, err error) {
 	return
 }
 
-func (s ThingWeaviateModel) WeaviateClassName() string {
+func (s *ThingWeaviateModel) WeaviateClassName() string {
 	return "Thing"
 }
 
-func (s ThingWeaviateModel) FullWeaviateClassSchema() models.Class {
+func (s *ThingWeaviateModel) FullWeaviateClassSchema() models.Class {
 	class := models.Class{
 		Class:      s.WeaviateClassName(),
 		Properties: s.AllWeaviateClassSchemaProperties(),
@@ -244,14 +244,14 @@ func (s ThingWeaviateModel) FullWeaviateClassSchema() models.Class {
 	return class
 }
 
-func (s ThingWeaviateModel) CrossReferenceWeaviateClassSchema() models.Class {
+func (s *ThingWeaviateModel) CrossReferenceWeaviateClassSchema() models.Class {
 	return models.Class{
 		Class:      s.WeaviateClassName(),
 		Properties: s.WeaviateClassSchemaCrossReferenceProperties(),
 	}
 }
 
-func (s ThingWeaviateModel) NonCrossReferenceWeaviateClassSchema() models.Class {
+func (s *ThingWeaviateModel) NonCrossReferenceWeaviateClassSchema() models.Class {
 	class := models.Class{
 		Class:      s.WeaviateClassName(),
 		Properties: s.WeaviateClassSchemaNonCrossReferenceProperties(),
@@ -268,7 +268,7 @@ func (s ThingWeaviateModel) NonCrossReferenceWeaviateClassSchema() models.Class 
 	return class
 }
 
-func (s ThingWeaviateModel) WeaviateClassSchemaNonCrossReferenceProperties() []*models.Property {
+func (s *ThingWeaviateModel) WeaviateClassSchemaNonCrossReferenceProperties() []*models.Property {
 	properties := []*models.Property{}
 
 	ADoubleProperty := &models.Property{
@@ -463,7 +463,7 @@ func (s ThingWeaviateModel) WeaviateClassSchemaNonCrossReferenceProperties() []*
 	return properties
 }
 
-func (s ThingWeaviateModel) WeaviateClassSchemaCrossReferenceProperties() []*models.Property {
+func (s *ThingWeaviateModel) WeaviateClassSchemaCrossReferenceProperties() []*models.Property {
 	properties := []*models.Property{}
 
 	properties = append(properties, &models.Property{
@@ -482,11 +482,11 @@ func (s ThingWeaviateModel) WeaviateClassSchemaCrossReferenceProperties() []*mod
 	return properties
 }
 
-func (s ThingWeaviateModel) AllWeaviateClassSchemaProperties() []*models.Property {
+func (s *ThingWeaviateModel) AllWeaviateClassSchemaProperties() []*models.Property {
 	return append(s.WeaviateClassSchemaNonCrossReferenceProperties(), s.WeaviateClassSchemaCrossReferenceProperties()...)
 }
 
-func (s ThingWeaviateModel) Data() (map[string]interface{}, error) {
+func (s *ThingWeaviateModel) Data() (map[string]interface{}, error) {
 	data := map[string]interface{}{}
 
 	data["aDoubleText"] = fmt.Sprintf("%v", s.ADouble)
@@ -551,7 +551,7 @@ func (s ThingWeaviateModel) Data() (map[string]interface{}, error) {
 	return data, nil
 }
 
-func (s ThingWeaviateModel) addCrossReferenceData(data map[string]interface{}) map[string]interface{} {
+func (s *ThingWeaviateModel) addCrossReferenceData(data map[string]interface{}) map[string]interface{} {
 	if s.AssociatedThing != nil {
 		if lo.FromPtr(s.AssociatedThing.Id) != "" {
 			id := lo.FromPtr(s.AssociatedThing.Id)
@@ -576,11 +576,11 @@ func (s ThingWeaviateModel) addCrossReferenceData(data map[string]interface{}) m
 	return data
 }
 
-func (s ThingWeaviateModel) exists(ctx context.Context, client *weaviate.Client) (bool, error) {
+func (s *ThingWeaviateModel) exists(ctx context.Context, client *weaviate.Client) (bool, error) {
 	return client.Data().Checker().WithID(lo.FromPtr(s.Id)).WithClassName(s.WeaviateClassName()).Do(ctx)
 }
 
-func (s ThingWeaviateModel) Upsert(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
+func (s *ThingWeaviateModel) Upsert(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
 	data, err = s.Create(ctx, client, consistencyLevel)
 	if err != nil && strings.Contains(err.Error(), "already exists") {
 		err = s.Update(ctx, client, consistencyLevel)
@@ -588,7 +588,7 @@ func (s ThingWeaviateModel) Upsert(ctx context.Context, client *weaviate.Client,
 	return
 }
 
-func (s ThingWeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
+func (s *ThingWeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
 	if s.AssociatedThing != nil {
 		_, err = s.AssociatedThing.Upsert(ctx, client, consistencyLevel)
 		if err != nil {
@@ -621,7 +621,7 @@ func (s ThingWeaviateModel) Create(ctx context.Context, client *weaviate.Client,
 		Do(ctx)
 }
 
-func (s ThingWeaviateModel) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) (err error) {
+func (s *ThingWeaviateModel) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) (err error) {
 	if s.AssociatedThing != nil {
 		_, err = s.AssociatedThing.Upsert(ctx, client, consistencyLevel)
 		if err != nil {
@@ -654,7 +654,7 @@ func (s ThingWeaviateModel) Update(ctx context.Context, client *weaviate.Client,
 		Do(ctx)
 }
 
-func (s ThingWeaviateModel) Delete(ctx context.Context, client *weaviate.Client, consistencyLevel string) error {
+func (s *ThingWeaviateModel) Delete(ctx context.Context, client *weaviate.Client, consistencyLevel string) error {
 	return client.Data().Deleter().
 		WithClassName(s.WeaviateClassName()).
 		WithID(lo.FromPtr(s.Id)).
@@ -662,22 +662,22 @@ func (s ThingWeaviateModel) Delete(ctx context.Context, client *weaviate.Client,
 		Do(ctx)
 }
 
-func (s ThingWeaviateModel) EnsureFullClass(client *weaviate.Client, continueOnError bool) (err error) {
+func (s *ThingWeaviateModel) EnsureFullClass(client *weaviate.Client, continueOnError bool) (err error) {
 	if err = s.EnsureClassWithoutCrossReferences(client, continueOnError); err != nil {
 		return
 	}
 	return s.EnsureClassWithCrossReferences(client, continueOnError)
 }
 
-func (s ThingWeaviateModel) EnsureClassWithoutCrossReferences(client *weaviate.Client, continueOnError bool) error {
+func (s *ThingWeaviateModel) EnsureClassWithoutCrossReferences(client *weaviate.Client, continueOnError bool) error {
 	return ensureClass(client, s.NonCrossReferenceWeaviateClassSchema(), continueOnError)
 }
 
-func (s ThingWeaviateModel) EnsureClassWithCrossReferences(client *weaviate.Client, continueOnError bool) error {
+func (s *ThingWeaviateModel) EnsureClassWithCrossReferences(client *weaviate.Client, continueOnError bool) error {
 	return ensureClass(client, s.CrossReferenceWeaviateClassSchema(), continueOnError)
 }
 
-func (s ThingWeaviateModel) SummaryData() (string, error) {
+func (s *ThingWeaviateModel) SummaryData() (string, error) {
 	return getStringValue(s)
 }
 
@@ -690,7 +690,7 @@ type Thing2WeaviateModel struct {
 	Name string `json:"name" fake:"{name}"`
 }
 
-func (s Thing2WeaviateModel) ToProto() (theProto *Thing2, err error) {
+func (s *Thing2WeaviateModel) ToProto() (theProto *Thing2, err error) {
 	theProto = &Thing2{}
 
 	if s.Id != nil {
@@ -713,11 +713,11 @@ func (s *Thing2) ToWeaviateModel() (model *Thing2WeaviateModel, err error) {
 	return
 }
 
-func (s Thing2WeaviateModel) WeaviateClassName() string {
+func (s *Thing2WeaviateModel) WeaviateClassName() string {
 	return "Thing2"
 }
 
-func (s Thing2WeaviateModel) FullWeaviateClassSchema() models.Class {
+func (s *Thing2WeaviateModel) FullWeaviateClassSchema() models.Class {
 	class := models.Class{
 		Class:      s.WeaviateClassName(),
 		Properties: s.AllWeaviateClassSchemaProperties(),
@@ -726,14 +726,14 @@ func (s Thing2WeaviateModel) FullWeaviateClassSchema() models.Class {
 	return class
 }
 
-func (s Thing2WeaviateModel) CrossReferenceWeaviateClassSchema() models.Class {
+func (s *Thing2WeaviateModel) CrossReferenceWeaviateClassSchema() models.Class {
 	return models.Class{
 		Class:      s.WeaviateClassName(),
 		Properties: s.WeaviateClassSchemaCrossReferenceProperties(),
 	}
 }
 
-func (s Thing2WeaviateModel) NonCrossReferenceWeaviateClassSchema() models.Class {
+func (s *Thing2WeaviateModel) NonCrossReferenceWeaviateClassSchema() models.Class {
 	class := models.Class{
 		Class:      s.WeaviateClassName(),
 		Properties: s.WeaviateClassSchemaNonCrossReferenceProperties(),
@@ -742,7 +742,7 @@ func (s Thing2WeaviateModel) NonCrossReferenceWeaviateClassSchema() models.Class
 	return class
 }
 
-func (s Thing2WeaviateModel) WeaviateClassSchemaNonCrossReferenceProperties() []*models.Property {
+func (s *Thing2WeaviateModel) WeaviateClassSchemaNonCrossReferenceProperties() []*models.Property {
 	properties := []*models.Property{}
 
 	NameProperty := &models.Property{
@@ -755,17 +755,17 @@ func (s Thing2WeaviateModel) WeaviateClassSchemaNonCrossReferenceProperties() []
 	return properties
 }
 
-func (s Thing2WeaviateModel) WeaviateClassSchemaCrossReferenceProperties() []*models.Property {
+func (s *Thing2WeaviateModel) WeaviateClassSchemaCrossReferenceProperties() []*models.Property {
 	properties := []*models.Property{}
 
 	return properties
 }
 
-func (s Thing2WeaviateModel) AllWeaviateClassSchemaProperties() []*models.Property {
+func (s *Thing2WeaviateModel) AllWeaviateClassSchemaProperties() []*models.Property {
 	return append(s.WeaviateClassSchemaNonCrossReferenceProperties(), s.WeaviateClassSchemaCrossReferenceProperties()...)
 }
 
-func (s Thing2WeaviateModel) Data() (map[string]interface{}, error) {
+func (s *Thing2WeaviateModel) Data() (map[string]interface{}, error) {
 	data := map[string]interface{}{}
 
 	data["name"] = s.Name
@@ -775,15 +775,15 @@ func (s Thing2WeaviateModel) Data() (map[string]interface{}, error) {
 	return data, nil
 }
 
-func (s Thing2WeaviateModel) addCrossReferenceData(data map[string]interface{}) map[string]interface{} {
+func (s *Thing2WeaviateModel) addCrossReferenceData(data map[string]interface{}) map[string]interface{} {
 	return data
 }
 
-func (s Thing2WeaviateModel) exists(ctx context.Context, client *weaviate.Client) (bool, error) {
+func (s *Thing2WeaviateModel) exists(ctx context.Context, client *weaviate.Client) (bool, error) {
 	return client.Data().Checker().WithID(lo.FromPtr(s.Id)).WithClassName(s.WeaviateClassName()).Do(ctx)
 }
 
-func (s Thing2WeaviateModel) Upsert(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
+func (s *Thing2WeaviateModel) Upsert(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
 	data, err = s.Create(ctx, client, consistencyLevel)
 	if err != nil && strings.Contains(err.Error(), "already exists") {
 		err = s.Update(ctx, client, consistencyLevel)
@@ -791,7 +791,7 @@ func (s Thing2WeaviateModel) Upsert(ctx context.Context, client *weaviate.Client
 	return
 }
 
-func (s Thing2WeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
+func (s *Thing2WeaviateModel) Create(ctx context.Context, client *weaviate.Client, consistencyLevel string) (data *data.ObjectWrapper, err error) {
 	var dataMap map[string]interface{}
 	if dataMap, err = s.Data(); err != nil {
 		return
@@ -804,7 +804,7 @@ func (s Thing2WeaviateModel) Create(ctx context.Context, client *weaviate.Client
 		Do(ctx)
 }
 
-func (s Thing2WeaviateModel) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) (err error) {
+func (s *Thing2WeaviateModel) Update(ctx context.Context, client *weaviate.Client, consistencyLevel string) (err error) {
 	var dataMap map[string]interface{}
 	if dataMap, err = s.Data(); err != nil {
 		return
@@ -817,7 +817,7 @@ func (s Thing2WeaviateModel) Update(ctx context.Context, client *weaviate.Client
 		Do(ctx)
 }
 
-func (s Thing2WeaviateModel) Delete(ctx context.Context, client *weaviate.Client, consistencyLevel string) error {
+func (s *Thing2WeaviateModel) Delete(ctx context.Context, client *weaviate.Client, consistencyLevel string) error {
 	return client.Data().Deleter().
 		WithClassName(s.WeaviateClassName()).
 		WithID(lo.FromPtr(s.Id)).
@@ -825,41 +825,43 @@ func (s Thing2WeaviateModel) Delete(ctx context.Context, client *weaviate.Client
 		Do(ctx)
 }
 
-func (s Thing2WeaviateModel) EnsureFullClass(client *weaviate.Client, continueOnError bool) (err error) {
+func (s *Thing2WeaviateModel) EnsureFullClass(client *weaviate.Client, continueOnError bool) (err error) {
 	if err = s.EnsureClassWithoutCrossReferences(client, continueOnError); err != nil {
 		return
 	}
 	return s.EnsureClassWithCrossReferences(client, continueOnError)
 }
 
-func (s Thing2WeaviateModel) EnsureClassWithoutCrossReferences(client *weaviate.Client, continueOnError bool) error {
+func (s *Thing2WeaviateModel) EnsureClassWithoutCrossReferences(client *weaviate.Client, continueOnError bool) error {
 	return ensureClass(client, s.NonCrossReferenceWeaviateClassSchema(), continueOnError)
 }
 
-func (s Thing2WeaviateModel) EnsureClassWithCrossReferences(client *weaviate.Client, continueOnError bool) error {
+func (s *Thing2WeaviateModel) EnsureClassWithCrossReferences(client *weaviate.Client, continueOnError bool) error {
 	return ensureClass(client, s.CrossReferenceWeaviateClassSchema(), continueOnError)
 }
 
-func (s Thing2WeaviateModel) SummaryData() (string, error) {
+func (s *Thing2WeaviateModel) SummaryData() (string, error) {
 	return getStringValue(s)
 }
 
 func EnsureClasses(client *weaviate.Client, continueOnError bool) (err error) {
 	// create classes without cross references first so there are no errors about missing classes
-	err = ThingWeaviateModel{}.EnsureClassWithoutCrossReferences(client, continueOnError)
+	ThingWeaviateModelPointer := &ThingWeaviateModel{}
+	err = ThingWeaviateModelPointer.EnsureClassWithoutCrossReferences(client, continueOnError)
 	if !continueOnError && err != nil {
 		return
 	}
-	err = Thing2WeaviateModel{}.EnsureClassWithoutCrossReferences(client, continueOnError)
+	Thing2WeaviateModelPointer := &Thing2WeaviateModel{}
+	err = Thing2WeaviateModelPointer.EnsureClassWithoutCrossReferences(client, continueOnError)
 	if !continueOnError && err != nil {
 		return
 	}
 	// update classes including cross references
-	err = ThingWeaviateModel{}.EnsureClassWithCrossReferences(client, continueOnError)
+	err = ThingWeaviateModelPointer.EnsureClassWithCrossReferences(client, continueOnError)
 	if !continueOnError && err != nil {
 		return
 	}
-	err = Thing2WeaviateModel{}.EnsureClassWithCrossReferences(client, continueOnError)
+	err = Thing2WeaviateModelPointer.EnsureClassWithCrossReferences(client, continueOnError)
 	if !continueOnError && err != nil {
 		return
 	}

--- a/example/example.pb.weaviate.go
+++ b/example/example.pb.weaviate.go
@@ -613,6 +613,8 @@ func (s *ThingWeaviateModel) Create(ctx context.Context, client *weaviate.Client
 	if dataMap, err = s.Data(); err != nil {
 		return
 	}
+	dataBytes, _ := json.Marshal(dataMap)
+	logging.Log.WithField("data", string(dataBytes)).WithField("operation", "create").Info("sending data to weaviate")
 	return client.Data().Creator().
 		WithClassName(s.WeaviateClassName()).
 		WithProperties(dataMap).
@@ -646,6 +648,8 @@ func (s *ThingWeaviateModel) Update(ctx context.Context, client *weaviate.Client
 	if dataMap, err = s.Data(); err != nil {
 		return
 	}
+	dataBytes, _ := json.Marshal(dataMap)
+	logging.Log.WithField("data", string(dataBytes)).WithField("operation", "create").Info("sending data to weaviate")
 	return client.Data().Updater().
 		WithClassName(s.WeaviateClassName()).
 		WithID(lo.FromPtr(s.Id)).
@@ -796,6 +800,8 @@ func (s *Thing2WeaviateModel) Create(ctx context.Context, client *weaviate.Clien
 	if dataMap, err = s.Data(); err != nil {
 		return
 	}
+	dataBytes, _ := json.Marshal(dataMap)
+	logging.Log.WithField("data", string(dataBytes)).WithField("operation", "create").Info("sending data to weaviate")
 	return client.Data().Creator().
 		WithClassName(s.WeaviateClassName()).
 		WithProperties(dataMap).
@@ -809,6 +815,8 @@ func (s *Thing2WeaviateModel) Update(ctx context.Context, client *weaviate.Clien
 	if dataMap, err = s.Data(); err != nil {
 		return
 	}
+	dataBytes, _ := json.Marshal(dataMap)
+	logging.Log.WithField("data", string(dataBytes)).WithField("operation", "create").Info("sending data to weaviate")
 	return client.Data().Updater().
 		WithClassName(s.WeaviateClassName()).
 		WithID(lo.FromPtr(s.Id)).

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -122,7 +122,6 @@ func (b *Builder) Generate() (response *pluginpb.CodeGeneratorResponse, err erro
 			templateMap := map[string]any{
 				"messages": protoFile.Messages,
 			}
-			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/catalystsquad/app-utils-go/logging"})
 			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "strings"})
 			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "regexp"})
 			if err = tpl.Execute(&data, templateMap); err != nil {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -124,6 +124,8 @@ func (b *Builder) Generate() (response *pluginpb.CodeGeneratorResponse, err erro
 			}
 			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "strings"})
 			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/tidwall/gjson"})
+			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/catalystsquad/app-utils-go/logging"})
+			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/sirupsen/logrus"})
 			if err = tpl.Execute(&data, templateMap); err != nil {
 				return
 			}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -122,6 +122,7 @@ func (b *Builder) Generate() (response *pluginpb.CodeGeneratorResponse, err erro
 			templateMap := map[string]any{
 				"messages": protoFile.Messages,
 			}
+			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/catalystsquad/app-utils-go/logging"})
 			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "strings"})
 			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "regexp"})
 			if err = tpl.Execute(&data, templateMap); err != nil {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -123,9 +123,7 @@ func (b *Builder) Generate() (response *pluginpb.CodeGeneratorResponse, err erro
 				"messages": protoFile.Messages,
 			}
 			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "strings"})
-			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/tidwall/gjson"})
-			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/catalystsquad/app-utils-go/logging"})
-			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/sirupsen/logrus"})
+			g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "regexp"})
 			if err = tpl.Execute(&data, templateMap); err != nil {
 				return
 			}

--- a/plugin/weaviate_template.go
+++ b/plugin/weaviate_template.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 )
 
-var summaryRegex = regexp.MustCompile("[^a-zA-Z0-9 -_]+")
+var summaryRegex = regexp.MustCompile("[^-'\\\\.a-zA-Z0-9 ]+")
 
 {{ range .messages }}
 {{ if shouldGenerateMessage . }}
@@ -531,6 +531,7 @@ func getStringValue(x interface{}) (value string, err error) {
 	}
 	summaryString := summaryRegex.ReplaceAllString(string(jsonBytes), " ")
 	value = strings.ToLower(summaryString)
+	logging.Log.WithField("summary", value).Info("created summary")
 	return
 }
 `

--- a/plugin/weaviate_template.go
+++ b/plugin/weaviate_template.go
@@ -363,6 +363,8 @@ func (s *{{ structName . }}) Create(ctx context.Context, client *weaviate.Client
     if dataMap, err = s.Data(); err != nil {
       return
     }
+    dataBytes, _ := json.Marshal(dataMap)
+    logging.Log.WithField("data", string(dataBytes)).WithField("operation", "create").Info("sending data to weaviate")
 	return client.Data().Creator().
 		WithClassName(s.WeaviateClassName()).
 		WithProperties(dataMap).
@@ -401,6 +403,8 @@ func (s *{{ structName . }}) Update(ctx context.Context, client *weaviate.Client
     if dataMap, err = s.Data(); err != nil {
       return
     }
+    dataBytes, _ := json.Marshal(dataMap)
+	logging.Log.WithField("data", string(dataBytes)).WithField("operation", "create").Info("sending data to weaviate")
 	return client.Data().Updater().
 		WithClassName(s.WeaviateClassName()).
 		{{- if idFieldIsOptional . }}

--- a/plugin/weaviate_template.go
+++ b/plugin/weaviate_template.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 )
 
-var summaryRegex = regexp.MustCompile("[^a-zA-Z0-9 ]+")
+var summaryRegex = regexp.MustCompile("[^a-zA-Z0-9 -_]+")
 
 {{ range .messages }}
 {{ if shouldGenerateMessage . }}

--- a/plugin/weaviate_template.go
+++ b/plugin/weaviate_template.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 )
 
+var summaryRegex = regexp.MustCompile("[^a-zA-Z0-9 ]+")
+
 {{ range .messages }}
 {{ if shouldGenerateMessage . }}
 type {{ structName . }} struct {
@@ -527,17 +529,8 @@ func getStringValue(x interface{}) (value string, err error) {
 	if jsonBytes, err = json.Marshal(x); err != nil {
 		return
 	}
-    values := gjson.GetBytes(jsonBytes, "@values")
-	logging.Log.WithFields(logrus.Fields{"json": string(jsonBytes), "values": values.String()}).Info("building summary string")
-	builder := new(strings.Builder)
-	for _, result := range values.Array() {
-		resultString := result.String()
-		if resultString != "" {
-			builder.WriteString(resultString)
-			builder.WriteString(" ")
-		}
-	}
-	value = strings.ToLower(builder.String())
+	summaryString := summaryRegex.ReplaceAllString(string(jsonBytes), "")
+	value = strings.ToLower(summaryString)
 	return
 }
 `

--- a/plugin/weaviate_template.go
+++ b/plugin/weaviate_template.go
@@ -527,8 +527,10 @@ func getStringValue(x interface{}) (value string, err error) {
 	if jsonBytes, err = json.Marshal(x); err != nil {
 		return
 	}
+    values := gjson.GetBytes(jsonBytes, "@values")
+	logging.Log.WithFields(logrus.Fields{"json": string(jsonBytes), "values": values.String()}).Info("building summary string")
 	builder := new(strings.Builder)
-	for _, result := range gjson.GetBytes(jsonBytes, "@values").Array() {
+	for _, result := range values.Array() {
 		resultString := result.String()
 		if resultString != "" {
 			builder.WriteString(resultString)

--- a/plugin/weaviate_template.go
+++ b/plugin/weaviate_template.go
@@ -529,7 +529,7 @@ func getStringValue(x interface{}) (value string, err error) {
 	if jsonBytes, err = json.Marshal(x); err != nil {
 		return
 	}
-	summaryString := summaryRegex.ReplaceAllString(string(jsonBytes), "")
+	summaryString := summaryRegex.ReplaceAllString(string(jsonBytes), " ")
 	value = strings.ToLower(summaryString)
 	return
 }

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -30,8 +30,10 @@ import (
 const weaviateScheme = "http"
 const weaviateHost = "localhost:8080"
 
-var thingClass = ThingWeaviateModel{}.WeaviateClassName()
-var thing2Class = Thing2WeaviateModel{}.WeaviateClassName()
+var thingWeaviateModelPointer = &ThingWeaviateModel{}
+var thing2WeaviateModelPointer = &Thing2WeaviateModel{}
+var thingClass = thingWeaviateModelPointer.WeaviateClassName()
+var thing2Class = thing2WeaviateModelPointer.WeaviateClassName()
 var weaviateGraphqlUrl = fmt.Sprintf("%s://%s/v1/graphql", weaviateScheme, weaviateHost)
 var httpClient = &http.Client{}
 var weaviateClient = client.New(client.Config{

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -90,15 +90,20 @@ func (s *PluginSuite) TestPlugin() {
 	thing.OptionalAssociatedThing = &associatedThing2
 	thing.RepeatedMessages = []*Thing2{&associatedThing3, &associatedThing4}
 	require.NoError(s.T(), err)
-	optionalAssociatedThingModel, err := thing.OptionalAssociatedThing.ToWeaviateModel()
-	require.NoError(s.T(), err)
-	_, err = optionalAssociatedThingModel.Create(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
-	require.NoError(s.T(), err)
-	// create thing
+	// index thing
 	thingModel, err := thing.ToWeaviateModel()
 	require.NoError(s.T(), err)
 	_, err = thingModel.Create(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
 	require.NoError(s.T(), err)
+	// index thing references
+	_, err = thingModel.AssociatedThing.Upsert(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
+	require.NoError(s.T(), err)
+	_, err = thingModel.OptionalAssociatedThing.Upsert(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
+	require.NoError(s.T(), err)
+	for _, thing := range thingModel.RepeatedMessages {
+		_, err = thing.Upsert(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
+		require.NoError(s.T(), err)
+	}
 	// query for thing
 	response := s.queryForThings(nil)
 	things, err := ThingWeaviateModelsFromGraphqlResult(response)
@@ -206,6 +211,68 @@ func (s *PluginSuite) TestUpsert() {
 	require.NoError(s.T(), err)
 	// ensure the update is correct
 	assertProtoEquality(s.T(), thing, postUpdateResultThing, protocmp.IgnoreFields(&Thing{}, "associated_thing"))
+}
+
+func (s *PluginSuite) TestUpsertWithExistingCrossReferences() {
+	// create protos
+	thing := &Thing{}
+	associatedThing1 := Thing2{}
+	associatedThing2 := Thing2{}
+	associatedThing3 := Thing2{}
+	associatedThing4 := Thing2{}
+	// populate protos
+	err := gofakeit.Struct(&thing)
+	require.NoError(s.T(), err)
+	thing.ATimestamp = timestamppb.New(time.Now())
+	thing.OptionalTimestamp = timestamppb.New(time.Now())
+	thing.AStructField = &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"name": {
+				Kind: &structpb.Value_StringValue{
+					StringValue: gofakeit.Name(),
+				},
+			},
+		},
+	}
+	thing.ABytes = []byte(gofakeit.HackerPhrase())
+	err = gofakeit.Struct(&associatedThing1)
+	require.NoError(s.T(), err)
+	err = gofakeit.Struct(&associatedThing2)
+	require.NoError(s.T(), err)
+	err = gofakeit.Struct(&associatedThing3)
+	require.NoError(s.T(), err)
+	err = gofakeit.Struct(&associatedThing4)
+	require.NoError(s.T(), err)
+	// set associated protos
+	thing.AssociatedThing = &associatedThing1
+	thing.OptionalAssociatedThing = &associatedThing2
+	thing.RepeatedMessages = []*Thing2{&associatedThing3, &associatedThing4}
+	require.NoError(s.T(), err)
+	// index thing references first
+	thingModel, err := thing.ToWeaviateModel()
+	require.NoError(s.T(), err)
+	_, err = thingModel.AssociatedThing.Upsert(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
+	require.NoError(s.T(), err)
+	_, err = thingModel.OptionalAssociatedThing.Upsert(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
+	require.NoError(s.T(), err)
+	for _, thing := range thingModel.RepeatedMessages {
+		_, err = thing.Upsert(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
+		require.NoError(s.T(), err)
+	}
+	// index thing
+	_, err = thingModel.Upsert(context.Background(), weaviateClient, replication.ConsistencyLevel.ALL)
+	require.NoError(s.T(), err)
+	// query for thing
+	response := s.queryForThings(nil)
+	things, err := ThingWeaviateModelsFromGraphqlResult(response)
+	thingsMap := lo.KeyBy(things, func(item ThingWeaviateModel) string {
+		return *item.Id
+	})
+	resultThing := thingsMap[*thing.Id]
+	require.NotNil(s.T(), resultThing)
+	resultThingProto, err := resultThing.ToProto()
+	require.NoError(s.T(), err)
+	assertProtoEquality(s.T(), thing, resultThingProto)
 }
 
 func (s *PluginSuite) deleteClass(class string) {


### PR DESCRIPTION
- Simplified summary generation to use regex to be less error prone
- refactored create and upsert to create empty placeholder objects for cross references instead of calling upsert on cross references. Calling upsert creates a race condition where stale data can be indexed when older data is indexed after newer data